### PR TITLE
Cache solr-wrapper download to reduce build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - solr-tgz-cache-{{ checksum "tmp/solr-9.6.1.tgz" }}
+            - solr-tgz-cache-{{ checksum ".solr_wrapper.yml" }}
             - solr-tgz-cache-{{ .Branch }}
             - solr-tgz-cache-
 
@@ -24,9 +24,9 @@ jobs:
           name: Test suite
           command: bundle exec rake sc:test
       - save_cache:
+          key: solr-tgz-cache-{{ checksum ".solr_wrapper.yml" }}
           paths:
             - tmp/solr-9.6.1.tgz
-          key: solr-tgz-cache-{{ checksum "tmp/solr-9.6.1.tgz" }}
 
       - store_artifacts:
           path: tmp/capybara

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,21 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
-# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
-# See: https://circleci.com/docs/orb-intro/
 orbs:
-  # See the Ruby orb documentation here: https://circleci.com/developer/orbs/orb/circleci/ruby
   ruby: circleci/ruby@2.1.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
 jobs:
   build:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
     docker:
-      # Specify the version you desire here
-      # See: https://circleci.com/developer/images/image/cimg/ruby
       - image: cimg/ruby:3.3.4-browsers
 
-    # Add steps to the job
-    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
     steps:
-      # Checkout the code as the first step.
       - checkout
+      - restore_cache:
+          keys:
+            - solr-tgz-cache-{{ checksum "tmp/solr-9.6.1.tgz" }}
+            - solr-tgz-cache-{{ .Branch }}
+            - solr-tgz-cache-
+
       - run:
           name: Which bundler?
           command: bundle -v
@@ -31,13 +23,15 @@ jobs:
       - run:
           name: Test suite
           command: bundle exec rake sc:test
+      - save_cache:
+          paths:
+            - tmp/solr-9.6.1.tgz
+          key: solr-tgz-cache-{{ checksum "tmp/solr-9.6.1.tgz" }}
+
       - store_artifacts:
           path: tmp/capybara
 
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run.
+  build:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,28 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/orb-intro/
 orbs:
+  # See the Ruby orb documentation here: https://circleci.com/developer/orbs/orb/circleci/ruby
   ruby: circleci/ruby@2.1.1
 
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
 jobs:
   build:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
     docker:
+      # Specify the version you desire here
+      # See: https://circleci.com/developer/images/image/cimg/ruby
       - image: cimg/ruby:3.3.4-browsers
 
+    # Add steps to the job
+    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
     steps:
+      # Checkout the code as the first step.
       - checkout
       - restore_cache:
           keys:
@@ -31,7 +45,10 @@ jobs:
       - store_artifacts:
           path: tmp/capybara
 
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  build:
+  build: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
     jobs:
       - build


### PR DESCRIPTION
solo-wrapper's download of Solr varies in time depending on the download server's availability. To minimize this time we can cache the download, based on a checksum of its configuration file.