### PR TITLE
Adds Breadcrumbs under header

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,2 +1,3 @@
 $primary: #57068C;
 $dark: #57068C;
+$breadcrumb-divider: quote(">");

--- a/app/components/blacklight/breadcrumbs_component.html.erb
+++ b/app/components/blacklight/breadcrumbs_component.html.erb
@@ -1,0 +1,11 @@
+<div class="row pt-2 ps-4">
+  <div class="col-12">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <% @items.each do |item| %>
+          <li class="breadcrumb-item"><%= link_to_if item[:href], item[:text], item[:href] %></li>
+        <% end %>
+      </ol>
+    </nav>
+  </div>
+</div>

--- a/app/components/blacklight/breadcrumbs_component.html.erb
+++ b/app/components/blacklight/breadcrumbs_component.html.erb
@@ -1,4 +1,4 @@
-<div class="row pt-2 ps-4">
+<div class="container mt-2">
   <div class="col-12">
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">

--- a/app/components/blacklight/breadcrumbs_component.rb
+++ b/app/components/blacklight/breadcrumbs_component.rb
@@ -1,0 +1,24 @@
+module Blacklight
+  class BreadcrumbsComponent < Blacklight::Component
+    def initialize(request:, repository:)
+      @request = request
+      @repository = repository
+
+      @items = [
+        { text: "NYU Libraries", href: "https://library.nyu.edu" },
+        { text: "Library Catalog", href: "http://bobcat.library.nyu.edu/nyu" }
+      ]
+
+      if @request.query_string.present?
+        @items << { text: "Archival Collections", href: "/" }
+        @items << { text: "Search" }
+      elsif @repository.present?
+        @items << { text: "Archival Collections", href: "/" }
+        @items << { text: @repository, href: @request.path }
+        @items << { text: "Search" }
+      else
+        @items << { text: "Archival Collections" }
+      end
+    end
+  end
+end

--- a/app/components/blacklight/top_navbar_component.html.erb
+++ b/app/components/blacklight/top_navbar_component.html.erb
@@ -10,3 +10,5 @@
     </div>
   </div>
 </nav>
+
+<%= render Blacklight::BreadcrumbsComponent.new(request: request, repository: params[:repository]) %>

--- a/spec/system/breadcrumbs_spec.rb
+++ b/spec/system/breadcrumbs_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe "breadcrumbs" do
+  context "on the landing page" do
+    it "links to NYU Libraries and the Library Catalog" do
+      visit "/"
+
+      within("ol.breadcrumb") do
+        expect(page).to have_link("NYU Libraries", href: "https://library.nyu.edu")
+        expect(page).to have_link("Library Catalog", href: "http://bobcat.library.nyu.edu/nyu")
+        expect(page).to have_text("Archival Collections")
+      end
+    end
+  end
+
+  context "on brief results page" do
+    it "links to Archival Collections and appends Search" do
+      visit "/"
+
+      fill_in "q", with: "foo"
+      click_button "Search"
+
+      within("ol.breadcrumb") do
+        expect(page).to have_link("NYU Libraries", href: "https://library.nyu.edu")
+        expect(page).to have_link("Library Catalog", href: "http://bobcat.library.nyu.edu/nyu")
+        expect(page).to have_link("Archival Collections", href: "/")
+        expect(page).to have_text("Search")
+      end
+    end
+  end
+
+  context "on repository/library pages" do
+    it "links to repository/library" do
+      visit "/fales"
+
+      within("ol.breadcrumb") do
+        expect(page).to have_link("NYU Libraries", href: "https://library.nyu.edu")
+        expect(page).to have_link("Library Catalog", href: "http://bobcat.library.nyu.edu/nyu")
+        expect(page).to have_link("Archival Collections", href: "/")
+        expect(page).to have_link("The Fales Library & Special Collections", href: "/fales")
+        expect(page).to have_text("Search")
+      end
+    end
+  end
+end

--- a/spec/system/brief_results_display_spec.rb
+++ b/spec/system/brief_results_display_spec.rb
@@ -12,7 +12,9 @@ describe "Brief Results Display", js: true do
     within("span.filter-value") { expect(page).to have_content("bloch") }
 
     click_button "Level"
-    click_link "Archival Collection"
+    within("div.blacklight-format_sim") do
+      click_link "Archival Collection"
+    end
 
     within("span.filter-format_sim") do
       within("span.filter-value") { expect(page).to have_content("Archival Collection") }
@@ -43,7 +45,9 @@ describe "Brief Results Display", js: true do
     visit "/"
 
     click_button "Level"
-    click_link "Archival Collection"
+    within("div.blacklight-format_sim") do
+      click_link "Archival Collection"
+    end
 
     within("span.filter-format_sim") do
       within("span.filter-value") { expect(page).to have_content("Archival Collection") }


### PR DESCRIPTION
Addresses #21 

## Screenshots

### Landing Page

<img width="1280" alt="Screenshot 2025-04-03 at 11 08 37 AM" src="https://github.com/user-attachments/assets/02975e8e-61b6-4e6e-a63c-acdb8e9a93b4" />

### Brief Results

<img width="1280" alt="Screenshot 2025-04-03 at 11 08 48 AM" src="https://github.com/user-attachments/assets/c6763a53-c9dd-4394-8c37-0ec02026e464" />

### Library Page

<img width="1280" alt="Screenshot 2025-04-03 at 11 08 33 AM" src="https://github.com/user-attachments/assets/5a9cacc3-7865-4654-bcfc-70a6d6eda679" />
